### PR TITLE
Fix nil pointer dereference in C_Initialize()

### DIFF
--- a/pkcs11.go
+++ b/pkcs11.go
@@ -57,7 +57,7 @@ func C_Initialize(pInitArgs C.CK_VOID_PTR) C.CK_RV {
 		return C.CKR_CRYPTOKI_ALREADY_INITIALIZED
 	}
 	cInitArgs := (*C.CK_C_INITIALIZE_ARGS)(unsafe.Pointer(pInitArgs))
-	if (cInitArgs.flags&C.CKF_OS_LOCKING_OK == 0) || (cInitArgs.pReserved != nil) {
+	if cInitArgs != nil && ((cInitArgs.flags&C.CKF_OS_LOCKING_OK == 0) || (cInitArgs.pReserved != nil)) {
 		return C.CKR_ARGUMENTS_BAD
 	}
 	var err error


### PR DESCRIPTION
It's legal to call C_Initialize with a NULL pointer, so pInitArgs must be checked for not being nil before dereferencing.